### PR TITLE
Remove symbols starting with 'tree_sitter_html_'

### DIFF
--- a/src/tree_sitter_html/scanner.cc
+++ b/src/tree_sitter_html/scanner.cc
@@ -279,32 +279,3 @@ struct Scanner {
 };
 
 }
-
-extern "C" {
-
-void *tree_sitter_html_external_scanner_create() {
-  return new Scanner();
-}
-
-bool tree_sitter_html_external_scanner_scan(void *payload, TSLexer *lexer,
-                                            const bool *valid_symbols) {
-  Scanner *scanner = static_cast<Scanner *>(payload);
-  return scanner->scan(lexer, valid_symbols);
-}
-
-unsigned tree_sitter_html_external_scanner_serialize(void *payload, char *buffer) {
-  Scanner *scanner = static_cast<Scanner *>(payload);
-  return scanner->serialize(buffer);
-}
-
-void tree_sitter_html_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
-  Scanner *scanner = static_cast<Scanner *>(payload);
-  scanner->deserialize(buffer, length);
-}
-
-void tree_sitter_html_external_scanner_destroy(void *payload) {
-  Scanner *scanner = static_cast<Scanner *>(payload);
-  delete scanner;
-}
-
-}


### PR DESCRIPTION
Including the file `scanner.cc` from tree-sitter-html causes a duplication of symbols and parsing errors when using both tree-sitter-html and tree-sitter-vue in the same program. It was particularly hard to detect because there was no compiler warning in our application (Semgrep).

You may not want to merge this pull request as is since the changes will be overridden when we run the script [scripts/update-html-scanner.sh](https://github.com/ikatyang/tree-sitter-vue/blob/master/scripts/update-html-scanner.sh). I would actually suggest removing the script since it's a little complicated and keep a patch file instead. I can do this if you think it's a good idea. Let us know.

Note that I didn't invest too much time into this because recent versions of tree-sitter no longer support C++ scanners. The current scanner would have to be translated to pure C (I briefly tried and failed). tree-sitter-html was already updated to provide a C scanner.
